### PR TITLE
Add Eraser Tool to PixelPad Core

### DIFF
--- a/Application/src/Services/DrawService.cpp
+++ b/Application/src/Services/DrawService.cpp
@@ -19,6 +19,7 @@ namespace PixelPad::Application
 		std::cout << "Size of DrawService: " << sizeof(*this) << std::endl; // 120
 	}
 
+	// ToDo: Add unit tests
 	void DrawService::SelectTool(const ToolType& toolType)
 	{
 		if (m_currentTool)
@@ -49,8 +50,10 @@ namespace PixelPad::Application
 		}
 	}
 
+	// ToDo: Add unit tests
 	void DrawService::ProcessDrawInput(const PixelPad::Application::MouseButtonEvent& mouseButtonEvent)
 	{
+		// ToDo: Look into adding radius
 		PixelPad::Core::DrawCommand command
 		{
 			mouseButtonEvent.X,

--- a/Core.Tests/Tools/EraserToolTests.cpp
+++ b/Core.Tests/Tools/EraserToolTests.cpp
@@ -1,7 +1,126 @@
 #include <gtest/gtest.h>
 #include "Graphics/Canvas.hpp"
+#include "Tools/EraserTool.hpp"
+#include "Tools/DrawCommand.hpp"
 
 namespace PixelPad::Tests::Core
 {
+	TEST(EraserToolTests, Draw_ShouldSetCorrectPixelColor)
+	{
+		const int expectedColor = 0xFFFFFFFF;
+		PixelPad::Core::Canvas canvas{ 5, 5, 0 };
+		PixelPad::Core::EraserTool eraserTool{ canvas };
+		PixelPad::Core::DrawCommand drawCommand{ 2, 3, 42, true };
 
+		eraserTool.Draw(drawCommand);
+
+		EXPECT_EQ(canvas.GetPixel(drawCommand.X, drawCommand.Y), expectedColor);
+	}
+
+	TEST(EraserToolTests, Draw_ShouldNoThrowError_WhenOutOfBounds)
+	{
+		PixelPad::Core::Canvas canvas{ 5, 5, 0 };
+		PixelPad::Core::EraserTool eraserTool{ canvas };
+		PixelPad::Core::DrawCommand drawCommand1{ -1, -1, 123, true };
+		PixelPad::Core::DrawCommand drawCommand2{ 10, 10, 25, true };
+
+		EXPECT_NO_THROW(eraserTool.Draw(drawCommand1));
+		EXPECT_NO_THROW(eraserTool.Draw(drawCommand2));
+	}
+
+	TEST(EraserToolTests, Draw_ShouldUpdateMultiplePixels_WhenMultipleCallsAreMade)
+	{
+		const int expectedColor = 0xFFFFFFFF;
+		PixelPad::Core::Canvas canvas{ 6, 6, 0 };
+		PixelPad::Core::EraserTool eraserTool{ canvas };
+
+		eraserTool.Draw({ 1, 1, 200, true });
+		eraserTool.Draw({ 1, 1, 200, false });
+
+		eraserTool.Draw({ 2, 2, 190, true });
+		eraserTool.Draw({ 2, 2, 190, false });
+
+		eraserTool.Draw({ 3, 3, 18, true });
+		eraserTool.Draw({ 3, 3, 18, false });
+
+		EXPECT_EQ(canvas.GetPixel(1, 1), expectedColor);
+		EXPECT_EQ(canvas.GetPixel(2, 2), expectedColor);
+		EXPECT_EQ(canvas.GetPixel(3, 3), expectedColor);
+	}
+
+	TEST(EraserToolTests, Draw_ShouldNotThrowError_WhenNegativeCoordinatesArePassed)
+	{
+		PixelPad::Core::Canvas canvas{ 6, 6, 0 };
+		PixelPad::Core::EraserTool eraserTool{ canvas };
+		PixelPad::Core::DrawCommand drawCommand{ -1, -1, 240, true };
+
+		EXPECT_NO_THROW(eraserTool.Draw(drawCommand));
+	}
+
+	TEST(EraserToolTests, Draw_ShouldOverwritePixelColor_WhenPixelIsAlreadyColored)
+	{
+		const int expectedColor = 0xFFFFFFFF;
+		PixelPad::Core::Canvas canvas{ 6, 6, 100 };
+		PixelPad::Core::EraserTool eraserTool{ canvas };
+		PixelPad::Core::DrawCommand drawCommand1{ 1, 1, 2, true };
+		PixelPad::Core::DrawCommand drawCommand2{ 1, 1, 100, true };
+
+		eraserTool.Draw(drawCommand1);
+		eraserTool.Draw(drawCommand2);
+
+		EXPECT_EQ(canvas.GetPixel(drawCommand2.X, drawCommand2.Y), expectedColor);
+	}
+
+	TEST(EraserToolTests, Draw_ShouldSetPixelColor_WhenMinEdgeCoordinatesAreUsed)
+	{
+		const int expectedColor = 0xFFFFFFFF;
+		PixelPad::Core::Canvas canvas{ 1, 1, 0 };
+		PixelPad::Core::EraserTool eraserTool{ canvas };
+		PixelPad::Core::DrawCommand drawCommand{ 0, 0, 200, true };
+
+		eraserTool.Draw(drawCommand);
+
+		EXPECT_EQ(canvas.GetPixel(drawCommand.X, drawCommand.Y), expectedColor);
+	}
+
+	TEST(EraserToolTests, Draw_ShouldSetPixelColor_WhenMaxEdgeCoordinatesAreUsed)
+	{
+		const int expectedColor = 0xFFFFFFFF;
+		PixelPad::Core::Canvas canvas{ 5, 5, 0 };
+		PixelPad::Core::EraserTool eraserTool{ canvas };
+		PixelPad::Core::DrawCommand drawCommand{ 4, 4, 155, true };
+
+		eraserTool.Draw(drawCommand);
+
+		EXPECT_EQ(canvas.GetPixel(drawCommand.X, drawCommand.Y), expectedColor);
+	}
+
+	TEST(EraserToolTests, Draw_ShouldEraseInterpolatedPath_WhenDraggedAcrossCanvas)
+	{
+		const int expectedColor = 0xFFFFFFFF;
+		PixelPad::Core::Canvas canvas{ 10, 10, 0 };
+		PixelPad::Core::EraserTool eraserTool{ canvas };
+
+		eraserTool.Draw({ 1, 1, 123, true });
+		eraserTool.Draw({ 5, 5, 123, true });
+		eraserTool.Draw({ 5, 5, 123, false });
+
+		EXPECT_EQ(canvas.GetPixel(1, 1), expectedColor);
+		EXPECT_EQ(canvas.GetPixel(3, 3), expectedColor);
+		EXPECT_EQ(canvas.GetPixel(5, 5), expectedColor);
+	}
+
+	TEST(EraserToolTests, Draw_ShouldResetLastCoordinates_WhenMouseReleased)
+	{
+		const int expectedColor = 0xFFFFFFFF;
+		PixelPad::Core::Canvas canvas{ 5, 5, 0 };
+		PixelPad::Core::EraserTool eraserTool{ canvas };
+
+		eraserTool.Draw({ 2, 2, 100, true });
+		eraserTool.Draw({ 3, 3, 100, false });
+
+		eraserTool.Draw({ 4, 4, 100, true });
+
+		EXPECT_EQ(canvas.GetPixel(4, 4), expectedColor);
+	}
 }

--- a/Core/include/Tools/EraserTool.hpp
+++ b/Core/include/Tools/EraserTool.hpp
@@ -14,7 +14,13 @@ namespace PixelPad::Core
 		void Draw(const DrawCommand& command) override;
 
 	private:
+		bool HasPreviousCoordinates() const;
+		void DrawEraserLine(int startX, int startY, int endX, int endY);
+		void DrawEraserCircle(int centerX, int centerY);
+
+	private:
 		Canvas& m_canvas;
+		unsigned int m_eraseColor;
 		int m_lastXCoordinate;
 		int m_lastYCoordinate;
 	};

--- a/Core/src/Tools/EraserTool.cpp
+++ b/Core/src/Tools/EraserTool.cpp
@@ -5,6 +5,7 @@ namespace PixelPad::Core
 {
 	EraserTool::EraserTool(Canvas& canvas) :
 		m_canvas(canvas),
+		m_eraseColor(0xFFFFFFFF),
 		m_lastXCoordinate(-1),
 		m_lastYCoordinate(-1)
 	{
@@ -13,11 +14,53 @@ namespace PixelPad::Core
 
 	void EraserTool::Reset()
 	{
-
+		m_lastXCoordinate = -1;
+		m_lastYCoordinate = -1;
 	}
 
 	void EraserTool::Draw(const DrawCommand& command)
 	{
+		if (!command.IsPressed)
+		{
+			Reset();
+			return;
+		}
 
+		if (HasPreviousCoordinates())
+		{
+			DrawEraserLine(m_lastXCoordinate, m_lastYCoordinate, command.X, command.Y);
+		}
+		else
+		{
+			DrawEraserCircle(command.X, command.Y);
+		}
+
+		m_lastXCoordinate = command.X;
+		m_lastYCoordinate = command.Y;
+	}
+
+	bool EraserTool::HasPreviousCoordinates() const
+	{
+		return m_lastXCoordinate >= 0 && m_lastYCoordinate >= 0;
+	}
+
+	void EraserTool::DrawEraserLine(int startX, int startY, int endX, int endY)
+	{
+		int deltaX = endX - startX;
+		int deltaY = endY - startY;
+		int interpolationSteps = std::max(std::abs(deltaX), std::abs(deltaY));
+
+		for (int step = 0; step <= interpolationSteps; step++)
+		{
+			float progress = step / static_cast<float>(interpolationSteps);
+			int interpolatedX = static_cast<int>(startX + progress * deltaX);
+			int interpolatedY = static_cast<int>(startY + progress * deltaY);
+			DrawEraserCircle(interpolatedX, interpolatedY);
+		}
+	}
+
+	void EraserTool::DrawEraserCircle(int centerX, int centerY)
+	{
+		m_canvas.DrawCircleFilled(centerX, centerY, 10, m_eraseColor);
 	}
 }

--- a/Core/src/Tools/PencilTool.cpp
+++ b/Core/src/Tools/PencilTool.cpp
@@ -19,22 +19,22 @@ namespace PixelPad::Core
 
 	void PencilTool::Draw(const DrawCommand& command)
 	{
-		if (command.IsPressed)
+		if (!command.IsPressed)
 		{
-			if (m_lastXCoordinate >= 0 && m_lastYCoordinate >= 0)
-			{
-				m_canvas.DrawLine(m_lastXCoordinate, m_lastYCoordinate, command.X, command.Y, command.Color);
-			}
-			else
-			{
-				m_canvas.DrawPixel(command.X, command.Y, command.Color);
-			}
-			m_lastXCoordinate = command.X;
-			m_lastYCoordinate = command.Y;
+			Reset();
+			return;
+		}
+
+		if (m_lastXCoordinate >= 0 && m_lastYCoordinate >= 0)
+		{
+			m_canvas.DrawLine(m_lastXCoordinate, m_lastYCoordinate, command.X, command.Y, command.Color);
 		}
 		else
 		{
-			Reset();
+			m_canvas.DrawPixel(command.X, command.Y, command.Color);
 		}
+
+		m_lastXCoordinate = command.X;
+		m_lastYCoordinate = command.Y;
 	}
 }


### PR DESCRIPTION
- Implemented EraserTool with smooth line interpolation and circular erase area
- Eraser uses internal erase color for consistent behavior independent of input color
- Added comprehensive unit tests covering drawing, edge cases, and out-of-bounds safety
- Supports continuous erase strokes with proper state reset on mouse release
- Aligns with clean architecture principles by separating tool logic from canvas rendering