### PR TITLE
Add new Rectangle tool with logic & tests

### DIFF
--- a/Application/include/Enums/ToolType.hpp
+++ b/Application/include/Enums/ToolType.hpp
@@ -9,5 +9,6 @@ namespace PixelPad::Application
 		Line = 2,
 		Fill = 3,
 		Eraser = 4,
+		Rectangle = 5,
 	};
 }

--- a/Application/include/Graphics/DrawService.hpp
+++ b/Application/include/Graphics/DrawService.hpp
@@ -8,6 +8,7 @@
 #include "Tools/LineTool.hpp"
 #include "Tools/EraserTool.hpp"
 #include "Tools/FillTool.hpp"
+#include "Tools/RectangleTool.hpp"
 #include "Tools/ITool.hpp"
 
 #include <memory>
@@ -33,6 +34,7 @@ namespace PixelPad::Application
 		PixelPad::Core::LineTool m_lineTool;
         PixelPad::Core::EraserTool m_eraserTool;
 		PixelPad::Core::FillTool m_fillTool;
+		PixelPad::Core::RectangleTool m_rectangleTool;
 		PixelPad::Core::ITool* m_currentTool;
 		std::unique_ptr<PixelPad::Core::CanvasSnapshot> m_canvasSnapshot;
 	};

--- a/Application/src/Graphics/DrawService.cpp
+++ b/Application/src/Graphics/DrawService.cpp
@@ -13,6 +13,7 @@ namespace PixelPad::Application
 		m_lineTool{ canvas },
 		m_eraserTool{ canvas },
 		m_fillTool{ canvas },
+		m_rectangleTool{ canvas },
 		m_currentTool{ &m_pencilTool },
 		m_canvasSnapshot{ }
 	{
@@ -43,6 +44,10 @@ namespace PixelPad::Application
 
 		case PixelPad::Application::ToolType::Eraser:
 			m_currentTool = &m_eraserTool;
+			break;
+
+		case PixelPad::Application::ToolType::Rectangle:
+			m_currentTool = &m_rectangleTool;
 			break;
 
 		default:

--- a/Core.Tests/CMakeLists.txt
+++ b/Core.Tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${PIXEL_PAD_CORE_TESTS_TARGET_NAME}
     Tools/LineToolTests.cpp
     Tools/EraserToolTests.cpp
     Tools/FillToolTests.cpp
+    Tools/RectangleToolTests.cpp
 )
 
 target_include_directories(${PIXEL_PAD_CORE_TESTS_TARGET_NAME}

--- a/Core.Tests/Graphics/CanvasTests.cpp
+++ b/Core.Tests/Graphics/CanvasTests.cpp
@@ -202,6 +202,84 @@ namespace PixelPad::Tests::Core
         EXPECT_EQ(canvas.GetPixel(2, 2), 0);
     }
 
+    TEST(CanvasTests, DrawRectangle_ShouldFillBorder_WhenWithinRadius)
+    {
+       PixelPad::Core::Canvas canvas(10, 10, 0);
+        canvas.DrawRectangle(2, 2, 7, 7, 42);
+
+        for (int x = 2; x <= 7; ++x)
+        {
+            EXPECT_EQ(canvas.GetPixel(x, 2), 42);
+            EXPECT_EQ(canvas.GetPixel(x, 7), 42);
+        }
+
+        for (int y = 2; y <= 7; ++y)
+        {
+            EXPECT_EQ(canvas.GetPixel(2, y), 42);
+            EXPECT_EQ(canvas.GetPixel(7, y), 42);
+        }
+
+        for (int y = 3; y < 7; ++y)
+        {
+            for (int x = 3; x < 7; ++x)
+            {
+                EXPECT_EQ(canvas.GetPixel(x, y), 0);
+            }
+        }
+    }
+
+    TEST(CanvasTests, DrawRectangle_ShouldFillBorderOnLargeCanvas_WhenWithinBounds)
+    {
+        PixelPad::Core::Canvas canvas(1000, 1000, 0);
+        canvas.DrawRectangle(100, 100, 900, 900, 99);
+
+        for (int x = 100; x <= 900; ++x)
+        {
+            EXPECT_EQ(canvas.GetPixel(x, 100), 99);
+            EXPECT_EQ(canvas.GetPixel(x, 900), 99);
+        }
+
+        for (int y = 100; y <= 900; ++y)
+        {
+            EXPECT_EQ(canvas.GetPixel(100, y), 99);
+            EXPECT_EQ(canvas.GetPixel(900, y), 99);
+        }
+
+        for (int y = 101; y < 900; ++y)
+        {
+            for (int x = 101; x < 900; ++x)
+            {
+                EXPECT_EQ(canvas.GetPixel(x, y), 0);
+            }
+        }
+    }
+
+    TEST(CanvasTests, DrawRectangle_ShouldDrawSinglePixel_WhenStartEqualsEnd)
+    {
+        PixelPad::Core::Canvas canvas(10, 10, 0);
+
+        canvas.DrawRectangle(4, 4, 4, 4, 99);
+
+        EXPECT_EQ(canvas.GetPixel(4, 4), 99);
+    }
+
+    TEST(CanvasTests, DrawRectangle_ShouldNotCrash_WhenOutOfBounds)
+    {
+        PixelPad::Core::Canvas canvas(10, 10, 0);
+
+        EXPECT_NO_THROW(canvas.DrawRectangle(-5, -5, 15, 15, 1));
+    }
+
+    TEST(CanvasTests, DrawRectangle_ShouldHandleReversedCoordinates)
+    {
+        PixelPad::Core::Canvas canvas(10, 10, 0);
+
+        canvas.DrawRectangle(7, 7, 2, 2, 77);
+
+        EXPECT_EQ(canvas.GetPixel(2, 2), 77);
+        EXPECT_EQ(canvas.GetPixel(7, 7), 77);
+    }
+
     TEST(CanvasTests, GetPixel_ShouldReturnCorrectValue_WhenPixelWasSet)
     {
         PixelPad::Core::Canvas canvas(5, 5, 0);

--- a/Core.Tests/Tools/RectangleToolTests.cpp
+++ b/Core.Tests/Tools/RectangleToolTests.cpp
@@ -1,0 +1,165 @@
+#include <gtest/gtest.h>
+#include "Graphics/Canvas.hpp"
+#include "Tools/RectangleTool.hpp"
+#include "Tools/DrawCommand.hpp"
+
+namespace PixelPad::Tests::Core
+{
+	TEST(RectangleToolTests, Draw_ShouldDrawRectangleBorder_WhenPressedAndReleased)
+	{
+		const int end = 5;
+		const int expectedColor = 150;
+		PixelPad::Core::Canvas canvas{ 10, 10, 0 };
+		PixelPad::Core::RectangleTool rectangleTool{ canvas };
+
+		for (int i = 0; i <= end; i++)
+		{
+			rectangleTool.Draw({ i, 5, expectedColor, true });
+		}
+		rectangleTool.Draw({ 5, 5, expectedColor, false });
+
+		for (int x = 0; x <= end; x++)
+		{
+			EXPECT_EQ(canvas.GetPixel(x, 5), expectedColor);
+		}
+	}
+
+	TEST(RectangleToolTests, Draw_ShouldDrawSinglePixelRectangle_WhenPressedAndReleasedAtSamePoint)
+	{
+		PixelPad::Core::Canvas canvas{ 10, 10, 0 };
+		PixelPad::Core::RectangleTool rectangleTool{ canvas };
+
+		rectangleTool.Draw({ 5, 5, 200, true });
+		rectangleTool.Draw({ 5, 5, 200, false });
+
+		EXPECT_EQ(canvas.GetPixel(5, 5), 200);
+	}
+
+	TEST(RectangleToolTests, Draw_ShouldDrawCorrectRectangle_WhenDraggedFromTopLeftToBottomRight)
+	{
+		const int startX = 0;
+		const int startY = 0;
+		const int endX = 5;
+		const int endY = 5;
+		const int expectedColor = 150;
+
+		PixelPad::Core::Canvas canvas{ 10, 10, 0 };
+		PixelPad::Core::RectangleTool rectangleTool{ canvas };
+
+		rectangleTool.Draw({ startX, startY, expectedColor, true });
+		rectangleTool.Draw({ endX, endY, expectedColor, false });
+
+		for (int x = startX; x <= endX; ++x)
+		{
+			EXPECT_EQ(canvas.GetPixel(x, startY), expectedColor);
+			EXPECT_EQ(canvas.GetPixel(x, endY), expectedColor);
+		}
+
+		for (int y = startY; y <= endY; ++y)
+		{
+			EXPECT_EQ(canvas.GetPixel(startX, y), expectedColor);
+			EXPECT_EQ(canvas.GetPixel(endX, y), expectedColor);
+		}
+	}
+
+	TEST(RectangleToolTests, Draw_ShouldDrawCorrectRectangle_WhenDraggedFromBottomRightToTopLeft)
+	{
+		const int startX = 5;
+		const int startY = 5;
+		const int endX = 0;
+		const int endY = 0;
+		const int expectedColor = 150;
+
+		PixelPad::Core::Canvas canvas{ 10, 10, 0 };
+		PixelPad::Core::RectangleTool rectangleTool{ canvas };
+
+		rectangleTool.Draw({ startX, startY, expectedColor, true });
+		rectangleTool.Draw({ endX, endY, expectedColor, false });
+
+		for (int x = endX; x <= startX; ++x)
+		{
+			EXPECT_EQ(canvas.GetPixel(x, startY), expectedColor);
+			EXPECT_EQ(canvas.GetPixel(x, endY), expectedColor);
+		}
+
+		for (int y = endY; y <= startY; ++y)
+		{
+			EXPECT_EQ(canvas.GetPixel(startX, y), expectedColor);
+			EXPECT_EQ(canvas.GetPixel(endX, y), expectedColor);
+		}
+	}
+
+	TEST(RectangleToolTests, Draw_ShouldResetStartPoint_WhenDrawCompletes)
+	{
+		PixelPad::Core::Canvas canvas{ 10, 10, 0 };
+		PixelPad::Core::RectangleTool rectangleTool{ canvas };
+
+		rectangleTool.Draw({ 2, 2, 100, true });
+		rectangleTool.Draw({ 3, 3, 100, false });
+
+		rectangleTool.Draw({ 6, 6, 112, true });
+		rectangleTool.Draw({ 7, 7, 112, false });
+
+		EXPECT_EQ(canvas.GetPixel(2, 2), 100);
+		EXPECT_EQ(canvas.GetPixel(3, 3), 100);
+		EXPECT_EQ(canvas.GetPixel(6, 6), 112);
+		EXPECT_EQ(canvas.GetPixel(7, 7), 112);
+	}
+
+	TEST(RectangleToolTests, Draw_ShouldNotDraw_WhenCoordinatesAreCompletelyOutsideCanvas)
+	{
+		PixelPad::Core::Canvas canvas{ 10, 10, 0 };
+		PixelPad::Core::RectangleTool rectangleTool{ canvas };
+
+		rectangleTool.Draw({ -20, -20, 50, true });
+		rectangleTool.Draw({ -15, -15, 50, false });
+
+		for (int y = 0; y < 10; ++y)
+		{
+			for (int x = 0; x < 10; ++x)
+			{
+				EXPECT_EQ(canvas.GetPixel(x, y), 0);
+			}
+		}
+	}
+
+	TEST(RectangleToolTests, Draw_ShouldDrawBorderAndIgnoreOutOfBounds_WhenPressedAndReleasedOutsideOfCanvas)
+	{
+		const int expectedColor = 150;
+		PixelPad::Core::Canvas canvas{ 10, 10, 0 };
+		PixelPad::Core::RectangleTool rectangleTool{ canvas };
+
+		rectangleTool.Draw({ 8, 8, expectedColor, true });
+		rectangleTool.Draw({ 12, 12, expectedColor, false });
+
+		EXPECT_EQ(canvas.GetPixel(8, 8), expectedColor);
+		EXPECT_EQ(canvas.GetPixel(9, 8), expectedColor); 
+		EXPECT_EQ(canvas.GetPixel(8, 9), expectedColor); 
+
+		EXPECT_EQ(canvas.GetPixel(9, 9), 0);
+
+		EXPECT_EQ(canvas.GetPixel(10, 10), -1);
+		EXPECT_EQ(canvas.GetPixel(11, 11), -1);
+		EXPECT_EQ(canvas.GetPixel(12, 12), -1);
+	}
+
+	TEST(RectangleToolTests, Draw_ShouldNotDraw_WhenReleasedWithoutPriorPress)
+	{
+		PixelPad::Core::Canvas canvas{ 10, 10, 0 };
+		PixelPad::Core::RectangleTool rectangleTool{ canvas };
+
+		rectangleTool.Draw({ 5, 5, 100, false });
+
+		EXPECT_EQ(canvas.GetPixel(5, 5), 0);
+	}
+
+	TEST(RectangleToolTests, Draw_ShouldNotDraw_WhenOnlyPressedAndHeld)
+	{
+		PixelPad::Core::Canvas canvas{ 10, 10, 0 };
+		PixelPad::Core::RectangleTool rectangleTool{ canvas };
+
+		rectangleTool.Draw({ 5, 5, 100, true });
+
+		EXPECT_EQ(canvas.GetPixel(5, 5), 0);
+	}
+}

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -21,6 +21,9 @@ add_library(${PIXEL_PAD_CORE_TARGET_NAME}
     src/Tools/FillTool.cpp
     include/Tools/FillTool.hpp
 
+    src/Tools/RectangleTool.cpp
+    include/Tools/RectangleTool.hpp
+
     include/Tools/DrawCommand.hpp
 )
 

--- a/Core/include/Graphics/Canvas.hpp
+++ b/Core/include/Graphics/Canvas.hpp
@@ -14,6 +14,7 @@ namespace PixelPad::Core
 		void DrawLine(int startX, int startY, int endX, int endY, int color);
 		void DrawCircleFilled(int centerX, int centerY, int radius, int color);
 		void DrawCircleOutline(int centerX, int centerY, int radius, int color);
+		void DrawRectangle(int startX, int startY, int endX, int endY, int color);
 		void Resize(int width, int height);
 		void Fill(int color);
 		void FloodFill(int startX, int startY, int fillColor);

--- a/Core/include/Tools/RectangleTool.hpp
+++ b/Core/include/Tools/RectangleTool.hpp
@@ -1,0 +1,21 @@
+#pragma once 
+
+#include "Tools/ITool.hpp"
+#include "Graphics/Canvas.hpp"
+
+namespace PixelPad::Core
+{
+	class RectangleTool : public ITool
+	{
+	public:
+		RectangleTool(Canvas& canvas);
+		~RectangleTool() override = default;
+		void Reset() override;
+		void Draw(const DrawCommand& command) override;
+
+	private:
+		Canvas& m_canvas;
+		int m_lastXCoordinate;
+		int m_lastYCoordinate;
+	};
+}

--- a/Core/src/Graphics/Canvas.cpp
+++ b/Core/src/Graphics/Canvas.cpp
@@ -122,6 +122,55 @@ namespace PixelPad::Core
 		}
 	}
 
+	void Canvas::DrawRectangle(int startX, int startY, int endX, int endY, int color)
+	{
+		int topLeftX = std::min(startX, endX);
+		int topLeftY = std::min(startY, endY);
+		int width = std::abs(endX - startX) + 1;
+		int height = std::abs(endY - startY) + 1;
+		if (width <= 0 || height <= 0)
+			return;
+
+		int bottomRightX = topLeftX + width - 1;
+		int bottomRightY = topLeftY + height - 1;
+
+		// Top Horizontal Line
+		for (int pixelX = topLeftX; pixelX <= bottomRightX; ++pixelX)
+		{
+			if (!IsInBounds(pixelX, topLeftY))
+				continue;
+
+			m_canvas[topLeftY * m_width + pixelX] = color;
+		}
+
+		// Bottom horizontal line
+		for (int pixelX = topLeftX; pixelX <= bottomRightX; ++pixelX)
+		{
+			if (!IsInBounds(pixelX, bottomRightY))
+				continue;
+
+			m_canvas[bottomRightY * m_width + pixelX] = color;
+		}
+
+		// Left vertical line
+		for (int pixelY = topLeftY; pixelY <= bottomRightY; ++pixelY)
+		{
+			if (!IsInBounds(topLeftX, pixelY))
+				continue;
+
+			m_canvas[pixelY * m_width + topLeftX] = color;
+		}
+
+		// Right vertical line
+		for (int pixelY = topLeftY; pixelY <= bottomRightY; ++pixelY)
+		{
+			if (!IsInBounds(bottomRightX, pixelY))
+				continue;
+
+			m_canvas[pixelY * m_width + bottomRightX] = color;
+		}
+	}
+
 	void Canvas::Resize(int width, int height)
 	{
 		if (m_width == width && m_height == height)

--- a/Core/src/Tools/RectangleTool.cpp
+++ b/Core/src/Tools/RectangleTool.cpp
@@ -1,9 +1,9 @@
-#include "Tools/LineTool.hpp"
+#include "Tools/RectangleTool.hpp"
 #include "Tools/DrawCommand.hpp"
 
 namespace PixelPad::Core
 {
-	LineTool::LineTool(Canvas& canvas) :
+	RectangleTool::RectangleTool(Canvas& canvas) :
 		m_canvas(canvas),
 		m_lastXCoordinate(-1),
 		m_lastYCoordinate(-1)
@@ -11,15 +11,14 @@ namespace PixelPad::Core
 
 	}
 
-	void LineTool::Reset()
+	void RectangleTool::Reset()
 	{
 		m_lastXCoordinate = -1;
 		m_lastYCoordinate = -1;
 	}
 
-	void LineTool::Draw(const DrawCommand& command)
+	void RectangleTool::Draw(const DrawCommand& command)
 	{
-		// Capture the starting point on first press
 		if (command.IsPressed && m_lastXCoordinate == -1 && m_lastYCoordinate == -1)
 		{
 			m_lastXCoordinate = command.X;
@@ -27,10 +26,9 @@ namespace PixelPad::Core
 			return;
 		}
 
-		// On release, draw from the stored press point
 		if (!command.IsPressed && m_lastXCoordinate >= 0 && m_lastYCoordinate >= 0)
 		{
-			m_canvas.DrawLine(m_lastXCoordinate, m_lastYCoordinate, command.X, command.Y, command.Color);
+			m_canvas.DrawRectangle(m_lastXCoordinate, m_lastYCoordinate, command.X, command.Y, command.Color);
 			Reset();
 		}
 	}

--- a/Infrastructure/src/Inputs/SDLInput.cpp
+++ b/Infrastructure/src/Inputs/SDLInput.cpp
@@ -119,6 +119,10 @@ namespace PixelPad::Infrastructure
             m_eventBus.Publish(PixelPad::Application::ToolTypeChangedEvent{ PixelPad::Application::ToolType::Fill });
             break;
 
+		case SDLK_5:
+            m_eventBus.Publish(PixelPad::Application::ToolTypeChangedEvent{ PixelPad::Application::ToolType::Rectangle });
+			break;
+
         default:
             break;
         }


### PR DESCRIPTION
- Implemented a new RectangleTool for drawing rectangle borders on the canvas.
- Added core canvas logic to draw rectangle outlines with proper bounds checking.
- Included unit tests covering normal drawing, negative/out-of-bounds coordinates, and edge cases.
- Ensured behavior matches expected user experience similar to classic paint tools.