### PR TITLE
Feature/add ellipse draw logic

### DIFF
--- a/Application/include/Enums/ToolType.hpp
+++ b/Application/include/Enums/ToolType.hpp
@@ -10,5 +10,6 @@ namespace PixelPad::Application
 		Fill = 3,
 		Eraser = 4,
 		Rectangle = 5,
+		Ellipse = 6,
 	};
 }

--- a/Application/include/Graphics/DrawService.hpp
+++ b/Application/include/Graphics/DrawService.hpp
@@ -9,6 +9,7 @@
 #include "Tools/EraserTool.hpp"
 #include "Tools/FillTool.hpp"
 #include "Tools/RectangleTool.hpp"
+#include "Tools/EllipseTool.hpp"
 #include "Tools/ITool.hpp"
 
 #include <memory>
@@ -35,6 +36,7 @@ namespace PixelPad::Application
         PixelPad::Core::EraserTool m_eraserTool;
 		PixelPad::Core::FillTool m_fillTool;
 		PixelPad::Core::RectangleTool m_rectangleTool;
+		PixelPad::Core::EllipseTool m_ellipseTool;
 		PixelPad::Core::ITool* m_currentTool;
 		std::unique_ptr<PixelPad::Core::CanvasSnapshot> m_canvasSnapshot;
 	};

--- a/Application/src/Graphics/DrawService.cpp
+++ b/Application/src/Graphics/DrawService.cpp
@@ -14,6 +14,7 @@ namespace PixelPad::Application
 		m_eraserTool{ canvas },
 		m_fillTool{ canvas },
 		m_rectangleTool{ canvas },
+		m_ellipseTool{ canvas },
 		m_currentTool{ &m_pencilTool },
 		m_canvasSnapshot{ }
 	{
@@ -48,6 +49,10 @@ namespace PixelPad::Application
 
 		case PixelPad::Application::ToolType::Rectangle:
 			m_currentTool = &m_rectangleTool;
+			break;
+
+		case PixelPad::Application::ToolType::Ellipse:
+			m_currentTool = &m_ellipseTool;
 			break;
 
 		default:

--- a/Core.Tests/CMakeLists.txt
+++ b/Core.Tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(${PIXEL_PAD_CORE_TESTS_TARGET_NAME}
     Tools/EraserToolTests.cpp
     Tools/FillToolTests.cpp
     Tools/RectangleToolTests.cpp
+    Tools/EllipseToolTests.cpp
 )
 
 target_include_directories(${PIXEL_PAD_CORE_TESTS_TARGET_NAME}

--- a/Core.Tests/Graphics/CanvasTests.cpp
+++ b/Core.Tests/Graphics/CanvasTests.cpp
@@ -254,7 +254,7 @@ namespace PixelPad::Tests::Core
         }
     }
 
-    TEST(CanvasTests, DrawRectangle_ShouldDrawSinglePixel_WhenStartEqualsEnd)
+    TEST(CanvasTests, DrawRectangle_ShouldFillSinglePixel_WhenStartEqualsEnd)
     {
         PixelPad::Core::Canvas canvas(10, 10, 0);
 
@@ -278,6 +278,188 @@ namespace PixelPad::Tests::Core
 
         EXPECT_EQ(canvas.GetPixel(2, 2), 77);
         EXPECT_EQ(canvas.GetPixel(7, 7), 77);
+    }
+
+    TEST(CanvasTests, DrawEllipse_ShouldFillOutlineOfPerfectCircle_WhenGivenEqualWidthAndHeight)
+    {
+        PixelPad::Core::Canvas canvas(11, 11, 0);
+
+        canvas.DrawEllipse(5, 5, 3, 3, 155);
+
+        EXPECT_EQ(canvas.GetPixel(5, 2), 155); 
+        EXPECT_EQ(canvas.GetPixel(5, 8), 155); 
+        EXPECT_EQ(canvas.GetPixel(2, 5), 155); 
+        EXPECT_EQ(canvas.GetPixel(8, 5), 155);
+    }
+
+    TEST(CanvasTests, DrawEllipse_ShouldFillOutlineOfEllipse_WhenRadiusXDiffersFromRadiusY)
+    {
+		const int centerX = 8;
+		const int centerY = 8;
+		const int radiusX = 4;
+		const int radiusY = 6;
+		const int color = 155;
+        PixelPad::Core::Canvas canvas(20, 20, 0);
+
+        canvas.DrawEllipse(centerX, centerY, radiusX, radiusY, color);
+
+		EXPECT_EQ(canvas.GetPixel((centerX - radiusX), centerY), color); // Left Edge
+		EXPECT_EQ(canvas.GetPixel((centerX + radiusX), centerY), color); // Right Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY - radiusY)), color); // Top Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY + radiusY)), color); // Bottom Edge
+    }
+
+    TEST(CanvasTests, DrawEllipse_ShouldFillCorrectOutline_WhenCenterIsAtCanvasEdge)
+    {
+		const int centerX = 7;
+		const int centerY = 7;
+		const int radiusX = 2;
+		const int radiusY = 2;
+		const int color = 155;
+        PixelPad::Core::Canvas canvas(8, 8, 0);
+
+        canvas.DrawEllipse(centerX, centerY, radiusX, radiusY, color);
+
+		EXPECT_EQ(canvas.GetPixel((centerX - radiusX), centerY), color); // Left Edge
+		EXPECT_EQ(canvas.GetPixel((centerX + radiusX), centerY), -1); // Right Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY - radiusY)), color); // Top Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY + radiusY)), -1); // Bottom Edge
+    }
+
+    TEST(CanvasTests, DrawEllipse_ShouldFillNothing_WhenRadiusXOrRadiusYIsZero)
+    {
+		const int centerX = 4;
+		const int centerY = 3;
+		const int radiusX = 0;
+		const int radiusY = 0;
+		const int color = 155;
+        PixelPad::Core::Canvas canvas(8, 8, 0);
+
+        canvas.DrawEllipse(centerX, centerY, radiusX, radiusY, color);
+
+		EXPECT_EQ(canvas.GetPixel((centerX - radiusX), centerY), 0); // Left Edge
+		EXPECT_EQ(canvas.GetPixel((centerX + radiusX), centerY), 0); // Right Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY - radiusY)), 0); // Top Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY + radiusY)), 0); // Bottom Edge
+    }
+
+    TEST(CanvasTests, DrawEllipse_ShouldFillNothing_WhenRadiusXAndRadiusYAreNegative)
+    {
+		const int centerX = 5;
+		const int centerY = 5;
+		const int radiusX = -4;
+		const int radiusY = -5;
+		const int color = 155;
+        PixelPad::Core::Canvas canvas(8, 8, 0);
+
+        canvas.DrawEllipse(centerX, centerY, radiusX, radiusY, color);
+
+		EXPECT_EQ(canvas.GetPixel((centerX - radiusX), centerY), -1); // Left Edge
+		EXPECT_EQ(canvas.GetPixel((centerX + radiusX), centerY), 0); // Right Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY - radiusY)), -1); // Top Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY + radiusY)), 0); // Bottom Edge
+    }
+
+    TEST(CanvasTests, DrawEllipse_ShouldClipCorrectly_WhenEllipsePartiallyOutsideCanvas)
+    {
+		const int centerX = 6;
+		const int centerY = 5;
+		const int radiusX = 3;
+		const int radiusY = 4;
+		const int color = 155;
+        PixelPad::Core::Canvas canvas(8, 8, 0);
+
+        canvas.DrawEllipse(centerX, centerY, radiusX, radiusY, color);
+
+		EXPECT_EQ(canvas.GetPixel((centerX - radiusX), centerY), color); // Left Edge
+		EXPECT_EQ(canvas.GetPixel((centerX + radiusX), centerY), -1); // Right Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY - radiusY)), color); // Top Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY + radiusY)), -1); // Bottom Edge
+    }
+
+    TEST(CanvasTests, DrawEllipse_ShouldNotFillOutsideCanvas_WhenEllipseExceedsCanvasBounds)
+    {
+		const int centerX = 5;
+		const int centerY = 5;
+		const int radiusX = 20;
+		const int radiusY = 20;
+		const int color = 155;
+        PixelPad::Core::Canvas canvas(8, 8, 0);
+
+        canvas.DrawEllipse(centerX, centerY, radiusX, radiusY, color);
+
+		EXPECT_EQ(canvas.GetPixel(5, 5), 0);
+		EXPECT_EQ(canvas.GetPixel((centerX - radiusX), centerY), -1); // Left Edge
+		EXPECT_EQ(canvas.GetPixel((centerX + radiusX), centerY), -1); // Right Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY - radiusY)), -1); // Top Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY + radiusY)), -1); // Bottom Edge
+
+        for (int y = 0; y < 8; y++)
+        {
+            for (int x = 0; x < 8; x++)
+            {
+                EXPECT_EQ(canvas.GetPixel(x, y), 0);
+            }
+        }
+    }
+
+    TEST(CanvasTests, DrawEllipse_ShouldHandleSmallEllipses_WhenRadiusIsOne)
+    {
+		const int centerX = 5;
+		const int centerY = 5;
+		const int radiusX = 1;
+		const int radiusY = 1;
+		const int color = 155;
+        PixelPad::Core::Canvas canvas(8, 8, 0);
+
+        canvas.DrawEllipse(centerX, centerY, radiusX, radiusY, color);
+
+		EXPECT_EQ(canvas.GetPixel((centerX - radiusX), centerY), color); // Left Edge
+		EXPECT_EQ(canvas.GetPixel((centerX + radiusX), centerY), color); // Right Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY - radiusY)), color); // Top Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY + radiusY)), color); // Bottom Edge
+    }
+
+    TEST(CanvasTests, DrawEllipse_ShouldIgnoreDrawCalls_WhenCenterIsOutsideCanvas)
+    {
+		const int centerX = 12;
+		const int centerY = 12;
+		const int radiusX = 2;
+		const int radiusY = 3;
+		const int color = 155;
+        PixelPad::Core::Canvas canvas(8, 8, 0);
+
+        canvas.DrawEllipse(centerX, centerY, radiusX, radiusY, color);
+
+		EXPECT_EQ(canvas.GetPixel((centerX - radiusX), centerY), -1); // Left Edge
+		EXPECT_EQ(canvas.GetPixel((centerX + radiusX), centerY), -1); // Right Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY - radiusY)), -1); // Top Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY + radiusY)), -1); // Bottom Edge
+
+        for (int y = 0; y < 8; y++)
+        {
+            for (int x = 0; x < 8; x++)
+            {
+                EXPECT_EQ(canvas.GetPixel(x, y), 0);
+            }
+        }
+    }
+
+    TEST(CanvasTests, DrawEllipse_ShouldCompleteQuickly_ForLargeRadiusValues)
+    {
+		const int centerX = 500;
+		const int centerY = 440;
+		const int radiusX = 200;
+		const int radiusY = 150;
+		const int color = 155;
+        PixelPad::Core::Canvas canvas(800, 600, 0);
+
+        canvas.DrawEllipse(centerX, centerY, radiusX, radiusY, color);
+
+		EXPECT_EQ(canvas.GetPixel((centerX - radiusX), centerY), color); // Left Edge
+		EXPECT_EQ(canvas.GetPixel((centerX + radiusX), centerY), color); // Right Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY - radiusY)), color); // Top Edge
+		EXPECT_EQ(canvas.GetPixel(centerX, (centerY + radiusY)), color); // Bottom Edge
     }
 
     TEST(CanvasTests, GetPixel_ShouldReturnCorrectValue_WhenPixelWasSet)

--- a/Core.Tests/Tools/EllipseToolTests.cpp
+++ b/Core.Tests/Tools/EllipseToolTests.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+#include "Graphics/Canvas.hpp"
+#include "Tools/EllipseTool.hpp"
+#include "Tools/DrawCommand.hpp"
+
+namespace PixelPad::Tests::Core
+{
+    TEST(EllipseToolTests, Draw_ShouldFillOutlineOfPerfectCircle_WhenPressedAndReleased)
+    {
+        const int expectedColor = 155;
+        PixelPad::Core::Canvas canvas(11, 11, 0);
+		PixelPad::Core::EllipseTool ellipseTool(canvas);
+
+		ellipseTool.Draw({ 2, 2, expectedColor, true });
+		ellipseTool.Draw({ 8, 8, expectedColor, false });
+
+        EXPECT_EQ(canvas.GetPixel(5, 2), 155);
+        EXPECT_EQ(canvas.GetPixel(5, 8), 155);
+        EXPECT_EQ(canvas.GetPixel(2, 5), 155);
+        EXPECT_EQ(canvas.GetPixel(8, 5), 155);
+    }
+
+    TEST(EllipseToolTests, Draw_ShouldNotFill_WhenPressedOnly)
+    {
+        const int expectedColor = 0;
+        PixelPad::Core::Canvas canvas(10, 10, expectedColor);
+        PixelPad::Core::EllipseTool ellipseTool(canvas);
+
+        ellipseTool.Draw({ 3, 4, 100, true });
+
+        EXPECT_EQ(canvas.GetPixel(3, 4), expectedColor);
+    }
+
+    TEST(EllipseToolTests, Draw_ShouldReset_WhenRepeatedPressedAndReleased)
+    {
+        const int expectedFistColor = 100;
+        const int expectedSecondColor = 200;
+        PixelPad::Core::Canvas canvas(10, 10, 0);
+        PixelPad::Core::EllipseTool ellipseTool(canvas);
+
+        ellipseTool.Draw({ 2, 2, expectedFistColor, true });
+        ellipseTool.Draw({ 6, 6, expectedFistColor, false });
+
+        ellipseTool.Draw({ 1, 1, expectedSecondColor, true });
+        ellipseTool.Draw({ 3, 3, expectedSecondColor, false });
+
+        EXPECT_EQ(canvas.GetPixel(2, 1), expectedSecondColor);
+        EXPECT_EQ(canvas.GetPixel(3, 2), expectedSecondColor);
+        EXPECT_EQ(canvas.GetPixel(4, 2), expectedFistColor);
+    }
+}

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -24,6 +24,9 @@ add_library(${PIXEL_PAD_CORE_TARGET_NAME}
     src/Tools/RectangleTool.cpp
     include/Tools/RectangleTool.hpp
 
+    src/Tools/EllipseTool.cpp
+    include/Tools/EllipseTool.hpp
+
     include/Tools/DrawCommand.hpp
 )
 

--- a/Core/include/Graphics/Canvas.hpp
+++ b/Core/include/Graphics/Canvas.hpp
@@ -10,7 +10,7 @@ namespace PixelPad::Core
 		Canvas(int width, int height, uint32_t backgroundColor);
 		~Canvas() = default;
 		void Clear();
-		void DrawPixel(int x, int y, int color);
+		inline void DrawPixel(int x, int y, int color);
 		void DrawLine(int startX, int startY, int endX, int endY, int color);
 		void DrawCircleFilled(int centerX, int centerY, int radius, int color);
 		void DrawCircleOutline(int centerX, int centerY, int radius, int color);
@@ -33,4 +33,12 @@ namespace PixelPad::Core
 		int m_height{ 0 };
 		uint32_t m_backgroundColor{ 0xFFFFFFFF };
 	};
+
+	inline void Canvas::DrawPixel(int x, int y, int color)
+	{
+		if (!IsInBounds(x, y))
+			return;
+
+		m_canvas[y * m_width + x] = color;
+	}
 }

--- a/Core/include/Graphics/Canvas.hpp
+++ b/Core/include/Graphics/Canvas.hpp
@@ -15,6 +15,7 @@ namespace PixelPad::Core
 		void DrawCircleFilled(int centerX, int centerY, int radius, int color);
 		void DrawCircleOutline(int centerX, int centerY, int radius, int color);
 		void DrawRectangle(int startX, int startY, int endX, int endY, int color);
+		void DrawEllipse(int centerX, int centerY, int radiusX, int radiusY, int color);
 		void Resize(int width, int height);
 		void Fill(int color);
 		void FloodFill(int startX, int startY, int fillColor);

--- a/Core/include/Tools/EllipseTool.hpp
+++ b/Core/include/Tools/EllipseTool.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Tools/ITool.hpp"
+#include "Graphics/Canvas.hpp"
+
+namespace PixelPad::Core
+{ 
+	class EllipseTool : public ITool
+	{
+	public:
+		EllipseTool(Canvas& canvas);
+		~EllipseTool() override = default;
+		void Reset() override;
+		void Draw(const DrawCommand& command) override;
+
+	private:
+		Canvas& m_canvas;
+		int m_startXCoordinate;
+		int m_startYCoordinate;
+	};
+}

--- a/Core/src/Graphics/Canvas.cpp
+++ b/Core/src/Graphics/Canvas.cpp
@@ -171,6 +171,26 @@ namespace PixelPad::Core
 		}
 	}
 
+	void Canvas::DrawEllipse(int centerX, int centerY, int radiusX, int radiusY, int color)
+	{
+		if (radiusX <= 0 || radiusY <= 0)
+			return;
+
+		const float PI = 3.14159265358979323846f;
+		const int segments = 64;
+		for (int i = 0; i < segments; i++)
+		{
+			float angleRadians = 2.0f * PI * i / segments;
+			int pixelX = static_cast<int>(std::round(centerX + radiusX * std::cos(angleRadians)));
+			int pixelY = static_cast<int>(std::round(centerY + radiusY * std::sin(angleRadians)));
+
+			if (pixelX >= 0 && pixelX < m_width && pixelY >= 0 && pixelY < m_height)
+			{
+				m_canvas[pixelY * m_width + pixelX] = color;
+			}
+		}
+	}
+
 	void Canvas::Resize(int width, int height)
 	{
 		if (m_width == width && m_height == height)

--- a/Core/src/Tools/EllipseTool.cpp
+++ b/Core/src/Tools/EllipseTool.cpp
@@ -1,0 +1,39 @@
+#include "Tools/EllipseTool.hpp"
+#include "Tools/DrawCommand.hpp"
+
+namespace PixelPad::Core
+{
+	EllipseTool::EllipseTool(Canvas& canvas) :
+		m_canvas(canvas), 
+		m_startXCoordinate(-1), 
+		m_startYCoordinate(-1)
+	{
+
+	}
+
+	void EllipseTool::Reset()
+	{
+		m_startXCoordinate = -1;
+		m_startYCoordinate = -1;
+	}
+
+	void EllipseTool::Draw(const DrawCommand& command)
+	{
+		if (command.IsPressed && m_startXCoordinate == -1 && m_startYCoordinate == -1)
+		{
+			m_startXCoordinate = command.X;
+			m_startYCoordinate = command.Y;
+			return;
+		}
+
+		if (!command.IsPressed && m_startXCoordinate >= 0 && m_startYCoordinate >= 0)
+		{
+			auto centerX = (m_startXCoordinate + command.X) / 2;
+			auto centerY = (m_startYCoordinate + command.Y) / 2;
+			auto radiusX = abs(command.X - m_startXCoordinate) / 2;
+			auto radiusY = abs(command.Y - m_startYCoordinate) / 2;
+			m_canvas.DrawEllipse(centerX, centerY, radiusX, radiusY, command.Color);
+			Reset();
+		}
+	}
+}

--- a/Infrastructure/src/Inputs/SDLInput.cpp
+++ b/Infrastructure/src/Inputs/SDLInput.cpp
@@ -123,6 +123,10 @@ namespace PixelPad::Infrastructure
             m_eventBus.Publish(PixelPad::Application::ToolTypeChangedEvent{ PixelPad::Application::ToolType::Rectangle });
 			break;
 
+        case SDLK_6:
+            m_eventBus.Publish(PixelPad::Application::ToolTypeChangedEvent{ PixelPad::Application::ToolType::Ellipse });
+            break;
+
         default:
             break;
         }


### PR DESCRIPTION
- Implemented ellipse drawing logic in Canvas::DrawEllipse using the midpoint ellipse algorithm
- Added EllipseTool class to handle user input for drawing ellipses interactively
- Added unit tests for Canvas::DrawEllipse covering circle, ellipse, boundary, and edge cases
- Added unit tests for EllipseTool verifying drawing behavior, state reset, and color application
- Inline DrawPixel to reduce redundancy 
- Ensured performance and correctness for large ellipse drawing operations